### PR TITLE
Added ability to use custom capybara timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+Archived
+====
+
+Archived to S3 on 2013/09/17
+
+====
+
 jasminerice-runner
 ==================
 
@@ -9,17 +16,17 @@ Usage
 Add it to your Gemfile
 
     gem "jasminerice-runner"
-    
+
 Add this to your spec.js:
 
     #= require jasminerice_reporter
-  
+
 Then, run the rake task
 
     rake jasminerice:run
-    
+
 To switch drivers, in a config/initializer
 
     Jasminerice::Runner.capybara_driver = :webkit
-    
+
 Default driver is :selenium

--- a/lib/jasminerice-runner.rb
+++ b/lib/jasminerice-runner.rb
@@ -1,6 +1,7 @@
 module Jasminerice
   class Runner
     cattr_accessor :capybara_driver
+    cattr_accessor :timeout
   end
   class JasmineRiceRunnerEngine < Rails::Engine
   end

--- a/lib/jasminerice-runner/runner.rb
+++ b/lib/jasminerice-runner/runner.rb
@@ -1,17 +1,21 @@
 module Jasminerice
   class Runner
-    
+
     include Capybara::DSL
-    
+
     def capybara_driver
       self.class.capybara_driver || :selenium
     end
-    
+
+    def timeout
+      self.class.timeout || 60
+    end
+
     def run
       Capybara.default_driver = capybara_driver
       visit "/jasmine"
       puts "Running jasmine specs"
-      wait_until { page.evaluate_script("window.jasmineRiceReporter.finished")}
+      wait_until (timeout) { page.evaluate_script("window.jasmineRiceReporter.finished")}
       passed = page.evaluate_script("window.jasmineRiceReporter.results.passedCount")
       failed = page.evaluate_script("window.jasmineRiceReporter.results.failedCount")
       total = page.evaluate_script("window.jasmineRiceReporter.results.totalCount")
@@ -30,13 +34,13 @@ module Jasminerice
           puts "\n"
         end
       end
-  
+
       if page.evaluate_script("window.jasmineRiceReporter.results.failedCount") == 0
         puts "Jasmine specs passed, yay!"
       else
         raise "Jasmine specs failed"
       end
     end
-    
+
   end
 end


### PR DESCRIPTION
If you have a lot of jasmine tests you may need to increase the wait time for your tests to complete.

Add the following to a config/initializer
`Jasminerice::Runner.timeout = 300`
