### PR TITLE
Add support for Capybara 2 and multiple Jasmine environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ if no environment is specified.
 
 For example, if you wanted to run all specs in admin_spec.js the rake task would be:
 
-    rake jasminerice:run["admin']
+    rake jasminerice:run["admin"]

--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ To switch drivers, in a config/initializer
     Jasminerice::Runner.capybara_driver = :webkit
     
 Default driver is :selenium
+
+Using Multiple Jasmine Environments
+-----------------------------------
+
+If your app has multiple jasmine environments, you can specify the runner
+to only run jasmine tests for that environment. Adding an environment will
+run the file "#{ENVIRONMENT}_spec.js". The default spec file (spec.js) will be run
+if no environment is specified.
+
+For example, if you wanted to run all specs in admin_spec.js the rake task would be:
+
+    rake jasminerice:run["admin']

--- a/lib/assets/javascripts/jasminerice_reporter.js.coffee
+++ b/lib/assets/javascripts/jasminerice_reporter.js.coffee
@@ -21,5 +21,5 @@ class JasminericeReporter
 # when capybara hits us before the onload function has run
 window.jasmineRiceReporter = new JasminericeReporter()
 
-jQuery ->
+document.addEventListener 'DOMContentLoaded', ->
   jasmine.getEnv().addReporter window.jasmineRiceReporter

--- a/lib/jasminerice-runner/runner.rb
+++ b/lib/jasminerice-runner/runner.rb
@@ -1,64 +1,75 @@
 module Jasminerice
   class Runner
-
     include Capybara::DSL
+
+    def initialize(environment)
+      @environment = environment
+    end
 
     def capybara_driver
       self.class.capybara_driver || :selenium
     end
 
-    def run(jasmine_environment)
+    def run
       Capybara.default_driver = capybara_driver
-      url = "/jasmine"
-
-      if jasmine_environment.present?
-        url += "?environment=#{jasmine_environment}"
-      end
-      visit url
+      visit jasmine_url
       print "Running jasmine specs"
 
-      begin
-        wait_for_finished
-      rescue
-        if jasmine_environment.present?
-          filename = "#{jasmine_environment}_spec.js"
-        else
-          filename = "spec.js"
-        end
-        puts "\njasmineRiceReporter not defined! Check your configuration to make\n" +
-             "sure that #{filename} exists and that jasminerice_reporter is included."
-      end
+      wait_for_finished
+      results = get_results
+      puts "Jasmine results - Passed: #{results[:passed]} Failed: #{results[:failed]} Total: #{results[:total]}"
+      failures = results[:failures]
 
-      passed = page.evaluate_script("window.jasmineRiceReporter.results.passedCount")
-      failed = page.evaluate_script("window.jasmineRiceReporter.results.failedCount")
-      total = page.evaluate_script("window.jasmineRiceReporter.results.totalCount")
-      failures = page.evaluate_script("window.jasmineRiceReporter.failedSpecs")
-      puts "Jasmine results - Passed: #{passed} Failed: #{failed} Total: #{total}"
-
-      if failures.size > 0
-        puts 'Jasmine failures:  '
-        for suiteName,suiteFailures in failures
-          puts "  " + suiteName + "\n"
-          for specName,specFailures in suiteFailures
-            puts "    " + specName + "\n"
-            for specFailure in specFailures
-              puts "      " + specFailure + "\n"
-            end
-          end
-          puts "\n"
-        end
-      end
-
-      if page.evaluate_script("window.jasmineRiceReporter.results.failedCount") == 0
+      if failures.size == 0
         puts "Jasmine specs passed, yay!"
       else
+        report_failures(failures)
         raise "Jasmine specs failed"
+      end
+    end
+
+    def jasmine_url
+      url = "/jasmine"
+      if @environment.present?
+        url += "?environment=#{@environment}"
+      end
+
+      url
+    end
+
+    def get_results
+      {
+        passed: page.evaluate_script("window.jasmineRiceReporter.results.passedCount"),
+        failed: page.evaluate_script("window.jasmineRiceReporter.results.failedCount"),
+        total: page.evaluate_script("window.jasmineRiceReporter.results.totalCount"),
+        failures: page.evaluate_script("window.jasmineRiceReporter.failedSpecs")
+      }
+    end
+
+    def report_failures(failures)
+      puts 'Jasmine failures:  '
+      for suiteName,suiteFailures in failures
+        puts "  " + suiteName + "\n"
+        for specName,specFailures in suiteFailures
+          puts "    " + specName + "\n"
+          for specFailure in specFailures
+            puts "      " + specFailure + "\n"
+          end
+        end
+        puts "\n"
       end
     end
 
     def wait_for_finished
       reporter = page.evaluate_script("window.jasmineRiceReporter")
       if reporter.nil?
+        if @environment.present?
+          filename = "#{@environment}_spec.js"
+        else
+          filename = "spec.js"
+        end
+        puts "\njasmineRiceReporter not defined! Check your configuration to make\n" +
+             "sure that #{filename} exists and that jasminerice_reporter is included."
         raise "Reporter not found"
       end
 

--- a/lib/jasminerice-runner/runner.rb
+++ b/lib/jasminerice-runner/runner.rb
@@ -7,16 +7,34 @@ module Jasminerice
       self.class.capybara_driver || :selenium
     end
 
-    def run
+    def run(jasmine_environment)
       Capybara.default_driver = capybara_driver
-      visit "/jasmine"
+      url = "/jasmine"
+
+      if jasmine_environment.present?
+        url += "?environment=#{jasmine_environment}"
+      end
+      visit url
       print "Running jasmine specs"
-      wait_for_finished
+
+      begin
+        wait_for_finished
+      rescue
+        if jasmine_environment.present?
+          filename = "#{jasmine_environment}_spec.js"
+        else
+          filename = "spec.js"
+        end
+        puts "\njasmineRiceReporter not defined! Check your configuration to make\n" +
+             "sure that #{filename} exists and that jasminerice_reporter is included."
+      end
+
       passed = page.evaluate_script("window.jasmineRiceReporter.results.passedCount")
       failed = page.evaluate_script("window.jasmineRiceReporter.results.failedCount")
       total = page.evaluate_script("window.jasmineRiceReporter.results.totalCount")
       failures = page.evaluate_script("window.jasmineRiceReporter.failedSpecs")
       puts "Jasmine results - Passed: #{passed} Failed: #{failed} Total: #{total}"
+
       if failures.size > 0
         puts 'Jasmine failures:  '
         for suiteName,suiteFailures in failures
@@ -41,8 +59,6 @@ module Jasminerice
     def wait_for_finished
       reporter = page.evaluate_script("window.jasmineRiceReporter")
       if reporter.nil?
-        puts "jasmineRiceReporter not defined! Check your configuration to make\n" +
-             "sure that jasminerice_reporter is included in spec.js"
         raise "Reporter not found"
       end
 

--- a/lib/jasminerice-runner/runner.rb
+++ b/lib/jasminerice-runner/runner.rb
@@ -10,8 +10,8 @@ module Jasminerice
     def run
       Capybara.default_driver = capybara_driver
       visit "/jasmine"
-      puts "Running jasmine specs"
-      wait_for_results
+      print "Running jasmine specs"
+      wait_for_finished
       passed = page.evaluate_script("window.jasmineRiceReporter.results.passedCount")
       failed = page.evaluate_script("window.jasmineRiceReporter.results.failedCount")
       total = page.evaluate_script("window.jasmineRiceReporter.results.totalCount")
@@ -38,15 +38,21 @@ module Jasminerice
       end
     end
 
-    def wait_for_results
+    def wait_for_finished
+      reporter = page.evaluate_script("window.jasmineRiceReporter")
+      if reporter.nil?
+        puts "jasmineRiceReporter not defined! Check your configuration to make\n" +
+             "sure that jasminerice_reporter is included in spec.js"
+        raise "Reporter not found"
+      end
+
       start = Time.now
       while true
         break if page.evaluate_script("window.jasmineRiceReporter.finished")
-        if Time.now > start + 5.seconds
-          puts "Results not ready yet"
-        end
         sleep 1
+        print "."
       end
+      print "\n"
     end
   end
 end

--- a/lib/jasminerice-runner/runner.rb
+++ b/lib/jasminerice-runner/runner.rb
@@ -1,17 +1,17 @@
 module Jasminerice
   class Runner
-    
+
     include Capybara::DSL
-    
+
     def capybara_driver
       self.class.capybara_driver || :selenium
     end
-    
+
     def run
       Capybara.default_driver = capybara_driver
       visit "/jasmine"
       puts "Running jasmine specs"
-      wait_until { page.evaluate_script("window.jasmineRiceReporter.finished")}
+      wait_for_results
       passed = page.evaluate_script("window.jasmineRiceReporter.results.passedCount")
       failed = page.evaluate_script("window.jasmineRiceReporter.results.failedCount")
       total = page.evaluate_script("window.jasmineRiceReporter.results.totalCount")
@@ -30,13 +30,23 @@ module Jasminerice
           puts "\n"
         end
       end
-  
+
       if page.evaluate_script("window.jasmineRiceReporter.results.failedCount") == 0
         puts "Jasmine specs passed, yay!"
       else
         raise "Jasmine specs failed"
       end
     end
-    
+
+    def wait_for_results
+      start = Time.now
+      while true
+        break if page.evaluate_script("window.jasmineRiceReporter.finished")
+        if Time.now > start + 5.seconds
+          puts "Results not ready yet"
+        end
+        sleep 1
+      end
+    end
   end
 end

--- a/lib/tasks/jasminerice-runner.rake
+++ b/lib/tasks/jasminerice-runner.rake
@@ -1,9 +1,10 @@
 namespace :jasminerice do
-  
+
   desc "run jasmine specs in jasmine rice"
-  task :run => :environment do
+  task :run, [:jasmine_environment] => :environment do |t, args|
     require "capybara/rails"
     require "jasminerice-runner/runner"
-    Jasminerice::Runner.new.run
+    args.with_defaults(jasmine_environment: nil)
+    Jasminerice::Runner.new.run(args[:jasmine_environment])
   end
 end

--- a/lib/tasks/jasminerice-runner.rake
+++ b/lib/tasks/jasminerice-runner.rake
@@ -4,7 +4,7 @@ namespace :jasminerice do
   task :run, [:jasmine_environment] => :environment do |t, args|
     require "capybara/rails"
     require "jasminerice-runner/runner"
-    args.with_defaults(jasmine_environment: nil)
-    Jasminerice::Runner.new.run(args[:jasmine_environment])
+    runner = Jasminerice::Runner.new(args[:jasmine_environment])
+    runner.run
   end
 end


### PR DESCRIPTION
This pull request updates the runner to be compatible with Capybara 2.0 while still keeping it backwards-compatible with version 1. It also adds support for multiple Jasmine environments and removes the jQuery dependency. 
