### PR TITLE
Retry in case of Capybara::Poltergeist::TimeoutError

### DIFF
--- a/lib/jasminerice-runner/version.rb
+++ b/lib/jasminerice-runner/version.rb
@@ -1,5 +1,5 @@
 module Jasminerice
   class Runner
-    VERSION = "0.0.4"
+    VERSION = "0.0.5"
   end
 end


### PR DESCRIPTION
When running Jasmine specs, sometimes the whole capybara -> poltergeist -> phantomjs chain hangs. This presents itself as a TimeoutError.

This quick little hack just retries failing specs up to 4 times before giving up. Each time it encounters a timeout, we restart the PhantomJS driver.

For more info, see the following:

https://github.com/teampoltergeist/poltergeist/issues/375
https://github.com/ariya/phantomjs/issues/12234
https://gist.github.com/afn/c04ccfe71d648763b306
